### PR TITLE
Update azure-pipelines.yml to use main branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 trigger:
-  - master
+  - main
   
 variables:
   tag: '$(Build.BuildId)'


### PR DESCRIPTION
This PR updates the azure-pipelines.yml file to use the `main` branch instead of `master`. It has been automatically generated and this might not have worked correctly, so please check it carefully.