### PR TITLE
ci: use per-target cache key for matrixed build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.run_on }}
+          key: ${{ matrix.target }}
 
       - name: build with cross
         if: matrix.builder == 'cross'


### PR DESCRIPTION
## Summary

The matrixed `build` job in `release.yml` uses `Swatinem/rust-cache`, but keyed the cache on `${{ matrix.run_on }}`. That value is **not** unique across matrix entries:

- Both Linux entries (`amd64` / `arm64`) use `ubuntu-latest`
- Both macOS entries (`amd64` / `arm64`) use `macos-latest`

So those entries shared one cache key and clobbered each other's caches. This swaps the key to `${{ matrix.target }}`, which is unique per matrix entry (each has a distinct Rust target triple).

## Notes

- The single-entry `check` and `test` jobs already get a unique cache key from their job name, so they were left unchanged.

https://claude.ai/code/session_01B7XPXJeg6J5SzS7N8kByA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7XPXJeg6J5SzS7N8kByA5)_