### PR TITLE
ci: publish multi-arch Docker image to GHCR on every main commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
       - "docs/**"
   pull_request:
     branches: [ main ]
+  release:
+    types: [published]
 
 permissions:
   id-token: write
@@ -15,7 +17,8 @@ env:
   CARGO_TERM_COLOR: always
   VERSION: "0.0.0-dev"
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  # Published as ghcr.io/sierrasoftworks/bender/bender (see docs/hosting).
+  IMAGE_NAME: ${{ github.repository }}/bender
 
   STAGING_DEPLOYMENT_APP_ID: 65d7542d-354d-4129-898c-8848be8d5ecd
   STAGING_FUNCTION_NAME: bender-sierrasoftworks-staging
@@ -82,15 +85,6 @@ jobs:
           toolchain: stable
           components: llvm-tools-preview
 
-      - name: install protoc
-        run: |
-          $protoc_url = "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.2/protoc-3.20.2-linux-x86_64.zip"
-          Write-Host "Downloading protoc from '$protoc_url'"
-          Invoke-WebRequest -OutFile protoc.zip -Uri $protoc_url
-          Expand-Archive protoc.zip -DestinationPath ../tools
-          Add-Content -Path $env:GITHUB_PATH -Value "$((Get-Item ./).Parent.FullName)/tools/bin"
-        shell: pwsh
-
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
 
@@ -146,7 +140,7 @@ jobs:
           - arch: "arm64"
             os: linux
             run_on: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             builder: cross
             cargo-flags: "--features openssl-vendored"
 
@@ -179,15 +173,22 @@ jobs:
           target: ${{ matrix.target }}
           components: llvm-tools-preview
 
+      # Set up the cache before fetching the versioned Cargo.toml.
+      # Swatinem/rust-cache derives its cache key from the contents of
+      # Cargo.toml/Cargo.lock, so restoring the version-bumped Cargo.toml first
+      # would change the key on release builds and prevent any cache from being
+      # restored, forcing a full rebuild every time.
+      - name: Setup Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Give each matrix entry its own cache scope so the jobs don't clobber
+          # one another's caches (cross-built targets in particular).
+          key: ${{ matrix.target }}
+
       - name: Fetch Versioned Cargo.toml
         uses: actions/download-artifact@v8
         with:
           name: cargofile
-
-      - name: Setup Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.target }}
 
       - name: build with cross
         if: matrix.builder == 'cross'
@@ -222,7 +223,9 @@ jobs:
     needs:
       - build
 
-    if: github.event_name == 'release'
+    # Publish a fresh multi-arch image for every commit that lands on main, as
+    # well as for tagged releases. Pull requests build binaries but do not push.
+    if: github.event_name == 'push' || github.event_name == 'release'
 
     permissions:
       contents: read
@@ -261,9 +264,11 @@ jobs:
           images: ${{ env.FULL_IMAGE_NAME }}
           tags: |
             type=ref,event=branch
+            type=sha,format=long
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Checkout code
         uses: actions/checkout@v7
@@ -306,7 +311,7 @@ jobs:
     needs:
       - docker-build
 
-    if: github.event_name == 'release'
+    if: github.event_name == 'push' || github.event_name == 'release'
 
     permissions:
       contents: read

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,9 +1,0 @@
-[target.aarch64-unknown-linux-gnu]
-pre-build = [
-    "apt update && apt install -y protobuf-compiler"
-]
-
-[target.x86_64-unknown-linux-gnu]
-pre-build = [
-    "apt update && apt install -y protobuf-compiler"
-]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,17 @@
-FROM clux/muslrust:stable as builder
-
-RUN apt-get update && apt-get install -y openssl libssl-dev unzip protobuf-compiler gcc
-
-WORKDIR /src
-
-# Pre-build all dependencies
-RUN USER=root cargo init --bin --name bender
-COPY ./Cargo.lock .
-COPY ./Cargo.toml .
-RUN cargo build --release --locked && rm -rf target/*/release/deps/bender*
-RUN rm src/*.rs
-
-# Add the source code
-COPY . .
-
-# Run the test suite
-RUN cargo test --release && rm -rf target/*/release/deps/bender*
-
-# Build the final executable of the project
-RUN cargo build --release --bin bender --locked
-
-# Ensure that the binary is at a known location for the next stage
-RUN mkdir /out && \
-    rm /src/target/*/release/deps/bender*.d && \
-    cp /src/target/*/release/deps/bender* /out/bender
-
+# NOTE: This Dockerfile depends on you building the bender binary first.
+# It will then package that binary into the image, and use that as the entrypoint.
+# This means that running `docker build` is not a repeatable way to build the same
+# image, but the benefit is much faster cross-platform builds; a net win.
+#
+# The binary is expected to be a statically linked (musl) executable placed at
+# ./bender in the build context (see .github/workflows/release.yml).
 FROM cgr.dev/chainguard/static:latest
 
-COPY --from=builder /out/bender /app/bender
-ADD ./quotes.json /app/quotes.json
+LABEL org.opencontainers.image.source=https://github.com/SierraSoftworks/bender
+LABEL org.opencontainers.image.description="Your unfriendly source of Futurama quotes"
+
+COPY ./bender /app/bender
+COPY ./quotes.json /app/quotes.json
 
 WORKDIR /app
 ENTRYPOINT [ "/app/bender" ]

--- a/docs/hosting/getting-started.md
+++ b/docs/hosting/getting-started.md
@@ -6,7 +6,7 @@ description: Let's get you started with running your own Bender server.
 
 ## Starting the Server
 
-We package up Bender as a Docker image which can be run on any Linux x86\_64 host. By default, the container will listen on port 8000.
+We package up Bender as a multi-arch Docker image which can be run on any Linux `x86_64` (`amd64`) or `arm64` host. By default, the container will listen on port 8000.
 
 ```
 $ docker pull ghcr.io/sierrasoftworks/bender/bender


### PR DESCRIPTION
Adapt Grey's build/publish pattern for Bender so a fresh linux/amd64 +
linux/arm64 image is pushed to ghcr.io on every commit merged to main
(and on tagged releases), instead of the docker jobs never running.

- Dockerfile now embeds a prebuilt static musl binary on chainguard/static
  instead of compiling in-container (faster, matches the artifact the
  workflow downloads)
- Build arm64 as aarch64-unknown-linux-musl so both arches are static and
  run in the scratch-like base image
- Run docker-build/docker-publish on push to main and releases; tag images
  with main, sha, latest (default branch) and semver (releases)
- Restore the build cache before fetching the versioned Cargo.toml so the
  version bump no longer busts the cache key
- Set IMAGE_NAME to <repo>/bender to match the documented
  ghcr.io/sierrasoftworks/bender/bender image
- Drop protoc/protobuf install steps and Cross.toml; the crate graph has no
  tonic-build/prost-build codegen so protoc is not needed to compile